### PR TITLE
add frozen abi requirements

### DIFF
--- a/program/build.rs
+++ b/program/build.rs
@@ -1,0 +1,23 @@
+//! Required for `solana-frozen-abi-macro` to work.
+extern crate rustc_version;
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    // Copied and adapted from
+    // https://github.com/Kimundi/rustc-version-rs/blob/1d692a965f4e48a8cb72e82cda953107c0d22f47/README.md#example
+    // Licensed under Apache-2.0 + MIT
+    match version_meta().unwrap().channel {
+        Channel::Stable => {
+            println!("cargo:rustc-cfg=RUSTC_WITHOUT_SPECIALIZATION");
+        }
+        Channel::Beta => {
+            println!("cargo:rustc-cfg=RUSTC_WITHOUT_SPECIALIZATION");
+        }
+        Channel::Nightly => {
+            println!("cargo:rustc-cfg=RUSTC_WITH_SPECIALIZATION");
+        }
+        Channel::Dev => {
+            println!("cargo:rustc-cfg=RUSTC_WITH_SPECIALIZATION");
+        }
+    }
+}

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,4 +1,7 @@
 //! Vote Program.
+// [Core BPF]: Required for `solana-frozen-abi-macro` to work.
+#![allow(incomplete_features)]
+#![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 
 #[cfg(all(target_os = "solana", feature = "bpf-entrypoint"))]
 mod entrypoint;


### PR DESCRIPTION
#### Problem

The Vote program uses `solana-frozen-abi` to define ABIs for a few different 
types. In order to use it, we need to include the build script and the 
specification annotation.

#### Summary of Changes

Add the build script and the specification annotation, setting up the crate for 
`solana-frozen-abi`.