### PR TITLE
init new state layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,10 +26,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "ark-bn254"
@@ -159,6 +177,17 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -545,6 +574,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +609,19 @@ name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "equivalent"
@@ -644,6 +697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +725,12 @@ dependencies = [
  "generic-array",
  "hmac",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "im"
@@ -1109,6 +1177,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1406,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-logger"
+version = "1.18.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5540574de96cac634cb9c82ba7635aab00cbc37a277d36fa1d491a43f3d6e5f8"
+dependencies = [
+ "env_logger",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
 name = "solana-program"
 version = "1.18.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,12 +1554,14 @@ dependencies = [
 name = "solana-vote-program"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
  "bincode",
  "log",
  "rustc_version",
  "serde",
  "solana-frozen-abi 2.0.0",
  "solana-frozen-abi-macro 2.0.0",
+ "solana-logger",
  "solana-program 2.0.0",
  "spl-program-error",
 ]
@@ -1519,6 +1629,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.58",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1703,6 +1822,37 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-targets"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -24,6 +24,10 @@ solana-frozen-abi = { git = "https://github.com/anza-xyz/agave", ref = "9706a646
 solana-program = { git = "https://github.com/anza-xyz/agave", ref = "9706a6464665f7ebd6ead47f0d12f853ccacbab9" }
 spl-program-error = "0.3.1"
 
+[target.'cfg(not(target_os = "solana"))'.dev-dependencies]
+arbitrary = { version = "1.3.2", features = ["derive"] }
+solana-logger = "1.18.2"
+
 [lib]
 crate-type = ["cdylib", "lib"]
 

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -7,6 +7,7 @@
 mod entrypoint;
 pub mod error;
 pub mod processor;
+pub mod state;
 
 // [Core BPF]: TODO: Program-test will not overwrite existing built-ins.
 // See https://github.com/solana-labs/solana/pull/35233.

--- a/program/src/state/authorized_voters.rs
+++ b/program/src/state/authorized_voters.rs
@@ -1,0 +1,113 @@
+#[cfg(test)]
+use arbitrary::Arbitrary;
+use {
+    serde::{Deserialize, Serialize},
+    solana_frozen_abi_macro::AbiExample,
+    solana_program::{clock::Epoch, pubkey::Pubkey},
+    std::collections::BTreeMap,
+};
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone, AbiExample)]
+#[cfg_attr(test, derive(Arbitrary))]
+pub struct AuthorizedVoters {
+    authorized_voters: BTreeMap<Epoch, Pubkey>,
+}
+
+impl AuthorizedVoters {
+    pub fn new(epoch: Epoch, pubkey: Pubkey) -> Self {
+        let mut authorized_voters = BTreeMap::new();
+        authorized_voters.insert(epoch, pubkey);
+        Self { authorized_voters }
+    }
+
+    pub fn get_authorized_voter(&self, epoch: Epoch) -> Option<Pubkey> {
+        self.get_or_calculate_authorized_voter_for_epoch(epoch)
+            .map(|(pubkey, _)| pubkey)
+    }
+
+    pub fn get_and_cache_authorized_voter_for_epoch(&mut self, epoch: Epoch) -> Option<Pubkey> {
+        let res = self.get_or_calculate_authorized_voter_for_epoch(epoch);
+
+        res.map(|(pubkey, existed)| {
+            if !existed {
+                self.authorized_voters.insert(epoch, pubkey);
+            }
+            pubkey
+        })
+    }
+
+    pub fn insert(&mut self, epoch: Epoch, authorized_voter: Pubkey) {
+        self.authorized_voters.insert(epoch, authorized_voter);
+    }
+
+    pub fn purge_authorized_voters(&mut self, current_epoch: Epoch) -> bool {
+        // Iterate through the keys in order, filtering out the ones
+        // less than the current epoch
+        let expired_keys: Vec<_> = self
+            .authorized_voters
+            .range(0..current_epoch)
+            .map(|(authorized_epoch, _)| *authorized_epoch)
+            .collect();
+
+        for key in expired_keys {
+            self.authorized_voters.remove(&key);
+        }
+
+        // Have to uphold this invariant b/c this is
+        // 1) The check for whether the vote state is initialized
+        // 2) How future authorized voters for uninitialized epochs are set
+        //    by this function
+        assert!(!self.authorized_voters.is_empty());
+        true
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.authorized_voters.is_empty()
+    }
+
+    pub fn first(&self) -> Option<(&u64, &Pubkey)> {
+        self.authorized_voters.iter().next()
+    }
+
+    pub fn last(&self) -> Option<(&u64, &Pubkey)> {
+        self.authorized_voters.iter().next_back()
+    }
+
+    pub fn len(&self) -> usize {
+        self.authorized_voters.len()
+    }
+
+    pub fn contains(&self, epoch: Epoch) -> bool {
+        self.authorized_voters.get(&epoch).is_some()
+    }
+
+    pub fn iter(&self) -> std::collections::btree_map::Iter<Epoch, Pubkey> {
+        self.authorized_voters.iter()
+    }
+
+    // Returns the authorized voter at the given epoch if the epoch is >= the
+    // current epoch, and a bool indicating whether the entry for this epoch
+    // exists in the self.authorized_voter map
+    fn get_or_calculate_authorized_voter_for_epoch(&self, epoch: Epoch) -> Option<(Pubkey, bool)> {
+        let res = self.authorized_voters.get(&epoch);
+        if res.is_none() {
+            // If no authorized voter has been set yet for this epoch,
+            // this must mean the authorized voter remains unchanged
+            // from the latest epoch before this one
+            let res = self.authorized_voters.range(0..epoch).next_back();
+
+            /*
+            if res.is_none() {
+                warn!(
+                    "Tried to query for the authorized voter of an epoch earlier
+                    than the current epoch. Earlier epochs have been purged"
+                );
+            }
+            */
+
+            res.map(|(_, pubkey)| (*pubkey, false))
+        } else {
+            res.map(|pubkey| (*pubkey, true))
+        }
+    }
+}

--- a/program/src/state/circ_buf.rs
+++ b/program/src/state/circ_buf.rs
@@ -1,0 +1,72 @@
+#[cfg(test)]
+use arbitrary::{Arbitrary, Unstructured};
+use {
+    serde::{Deserialize, Serialize},
+    solana_frozen_abi_macro::AbiExample,
+};
+
+// this is how many epochs a voter can be remembered for slashing
+const MAX_ITEMS: usize = 32;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, AbiExample)]
+pub struct CircBuf<I> {
+    buf: [I; MAX_ITEMS],
+    /// next pointer
+    idx: usize,
+    is_empty: bool,
+}
+
+impl<I: Default + Copy> Default for CircBuf<I> {
+    fn default() -> Self {
+        Self {
+            buf: [I::default(); MAX_ITEMS],
+            idx: MAX_ITEMS
+                .checked_sub(1)
+                .expect("`MAX_ITEMS` should be positive"),
+            is_empty: true,
+        }
+    }
+}
+
+impl<I> CircBuf<I> {
+    pub fn append(&mut self, item: I) {
+        // remember prior delegate and when we switched, to support later slashing
+        self.idx = self
+            .idx
+            .checked_add(1)
+            .and_then(|idx| idx.checked_rem(MAX_ITEMS))
+            .expect("`self.idx` should be < `MAX_ITEMS` which should be non-zero");
+
+        self.buf[self.idx] = item;
+        self.is_empty = false;
+    }
+
+    pub fn buf(&self) -> &[I; MAX_ITEMS] {
+        &self.buf
+    }
+
+    pub fn last(&self) -> Option<&I> {
+        if !self.is_empty {
+            Some(&self.buf[self.idx])
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+impl<'a, I: Default + Copy> Arbitrary<'a> for CircBuf<I>
+where
+    I: Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let mut circbuf = Self::default();
+
+        let len = u.arbitrary_len::<I>()?;
+        for _ in 0..len {
+            circbuf.append(I::arbitrary(u)?);
+        }
+
+        Ok(circbuf)
+    }
+}

--- a/program/src/state/lockout.rs
+++ b/program/src/state/lockout.rs
@@ -1,0 +1,96 @@
+#[cfg(test)]
+use arbitrary::Arbitrary;
+use {
+    serde::{Deserialize, Serialize},
+    solana_frozen_abi_macro::AbiExample,
+    solana_program::clock::Slot,
+};
+
+// Maximum number of votes to keep around, tightly coupled with
+// epoch_schedule::MINIMUM_SLOTS_PER_EPOCH
+pub const MAX_LOCKOUT_HISTORY: usize = 31;
+pub const INITIAL_LOCKOUT: usize = 2;
+
+#[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Copy, Clone, AbiExample)]
+#[cfg_attr(test, derive(Arbitrary))]
+pub struct Lockout {
+    slot: Slot,
+    confirmation_count: u32,
+}
+
+impl Lockout {
+    pub fn new(slot: Slot) -> Self {
+        Self::new_with_confirmation_count(slot, 1)
+    }
+
+    pub fn new_with_confirmation_count(slot: Slot, confirmation_count: u32) -> Self {
+        Self {
+            slot,
+            confirmation_count,
+        }
+    }
+
+    // The number of slots for which this vote is locked
+    pub fn lockout(&self) -> u64 {
+        (INITIAL_LOCKOUT as u64).pow(self.confirmation_count())
+    }
+
+    // The last slot at which a vote is still locked out. Validators should not
+    // vote on a slot in another fork which is less than or equal to this slot
+    // to avoid having their stake slashed.
+    pub fn last_locked_out_slot(&self) -> Slot {
+        self.slot.saturating_add(self.lockout())
+    }
+
+    pub fn is_locked_out_at_slot(&self, slot: Slot) -> bool {
+        self.last_locked_out_slot() >= slot
+    }
+
+    pub fn slot(&self) -> Slot {
+        self.slot
+    }
+
+    pub fn confirmation_count(&self) -> u32 {
+        self.confirmation_count
+    }
+
+    pub fn increase_confirmation_count(&mut self, by: u32) {
+        self.confirmation_count = self.confirmation_count.saturating_add(by)
+    }
+}
+
+#[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Copy, Clone, AbiExample)]
+#[cfg_attr(test, derive(Arbitrary))]
+pub struct LandedVote {
+    // Latency is the difference in slot number between the slot that was voted on (lockout.slot)
+    // and the slot in which the vote that added this Lockout landed.  For votes which were
+    // cast before versions of the validator software which recorded vote latencies, latency is
+    // recorded as 0.
+    pub latency: u8,
+    pub lockout: Lockout,
+}
+
+impl LandedVote {
+    pub fn slot(&self) -> Slot {
+        self.lockout.slot
+    }
+
+    pub fn confirmation_count(&self) -> u32 {
+        self.lockout.confirmation_count
+    }
+}
+
+impl From<LandedVote> for Lockout {
+    fn from(landed_vote: LandedVote) -> Self {
+        landed_vote.lockout
+    }
+}
+
+impl From<Lockout> for LandedVote {
+    fn from(lockout: Lockout) -> Self {
+        Self {
+            latency: 0,
+            lockout,
+        }
+    }
+}

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -1,0 +1,8 @@
+//! Vote Program state types.
+
+pub mod authorized_voters;
+pub mod circ_buf;
+pub mod lockout;
+pub mod tower_sync;
+pub mod vote;
+pub mod vote_state_update;

--- a/program/src/state/tower_sync.rs
+++ b/program/src/state/tower_sync.rs
@@ -1,0 +1,163 @@
+use {
+    crate::state::lockout::Lockout,
+    serde::{Deserialize, Serialize},
+    solana_frozen_abi_macro::{frozen_abi, AbiExample},
+    solana_program::{
+        clock::{Slot, UnixTimestamp},
+        hash::Hash,
+    },
+    std::collections::VecDeque,
+};
+
+#[frozen_abi(digest = "5VUusSTenF9vZ9eHiCprVe9ABJUHCubeDNCCDxykybZY")]
+#[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone, AbiExample)]
+pub struct TowerSync {
+    /// The proposed tower
+    pub lockouts: VecDeque<Lockout>,
+    /// The proposed root
+    pub root: Option<Slot>,
+    /// signature of the bank's state at the last slot
+    pub hash: Hash,
+    /// processing timestamp of last slot
+    pub timestamp: Option<UnixTimestamp>,
+    /// the unique identifier for the chain up to and
+    /// including this block. Does not require replaying
+    /// in order to compute.
+    pub block_id: Hash,
+}
+
+impl From<Vec<(Slot, u32)>> for TowerSync {
+    fn from(recent_slots: Vec<(Slot, u32)>) -> Self {
+        let lockouts: VecDeque<Lockout> = recent_slots
+            .into_iter()
+            .map(|(slot, confirmation_count)| {
+                Lockout::new_with_confirmation_count(slot, confirmation_count)
+            })
+            .collect();
+        Self {
+            lockouts,
+            root: None,
+            hash: Hash::default(),
+            timestamp: None,
+            block_id: Hash::default(),
+        }
+    }
+}
+
+impl TowerSync {
+    pub fn new(
+        lockouts: VecDeque<Lockout>,
+        root: Option<Slot>,
+        hash: Hash,
+        block_id: Hash,
+    ) -> Self {
+        Self {
+            lockouts,
+            root,
+            hash,
+            timestamp: None,
+            block_id,
+        }
+    }
+
+    pub fn slots(&self) -> Vec<Slot> {
+        self.lockouts.iter().map(|lockout| lockout.slot()).collect()
+    }
+
+    pub fn last_voted_slot(&self) -> Option<Slot> {
+        self.lockouts.back().map(|l| l.slot())
+    }
+}
+
+pub mod serde_tower_sync {
+    use {
+        super::*,
+        serde::{Deserialize, Deserializer, Serialize, Serializer},
+        solana_program::{serde_varint, short_vec},
+    };
+
+    #[derive(Deserialize, Serialize, AbiExample)]
+    struct LockoutOffset {
+        #[serde(with = "serde_varint")]
+        offset: Slot,
+        confirmation_count: u8,
+    }
+
+    #[derive(Deserialize, Serialize)]
+    struct CompactTowerSync {
+        root: Slot,
+        #[serde(with = "short_vec")]
+        lockout_offsets: Vec<LockoutOffset>,
+        hash: Hash,
+        timestamp: Option<UnixTimestamp>,
+        block_id: Hash,
+    }
+
+    pub fn serialize<S>(tower_sync: &TowerSync, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let lockout_offsets = tower_sync.lockouts.iter().scan(
+            tower_sync.root.unwrap_or_default(),
+            |slot, lockout| {
+                let Some(offset) = lockout.slot().checked_sub(*slot) else {
+                    return Some(Err(serde::ser::Error::custom("Invalid vote lockout")));
+                };
+                let Ok(confirmation_count) = u8::try_from(lockout.confirmation_count()) else {
+                    return Some(Err(serde::ser::Error::custom("Invalid confirmation count")));
+                };
+                let lockout_offset = LockoutOffset {
+                    offset,
+                    confirmation_count,
+                };
+                *slot = lockout.slot();
+                Some(Ok(lockout_offset))
+            },
+        );
+        let compact_tower_sync = CompactTowerSync {
+            root: tower_sync.root.unwrap_or(Slot::MAX),
+            lockout_offsets: lockout_offsets.collect::<Result<_, _>>()?,
+            hash: tower_sync.hash,
+            timestamp: tower_sync.timestamp,
+            block_id: tower_sync.block_id,
+        };
+        compact_tower_sync.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<TowerSync, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let CompactTowerSync {
+            root,
+            lockout_offsets,
+            hash,
+            timestamp,
+            block_id,
+        } = CompactTowerSync::deserialize(deserializer)?;
+        let root = (root != Slot::MAX).then_some(root);
+        let lockouts =
+            lockout_offsets
+                .iter()
+                .scan(root.unwrap_or_default(), |slot, lockout_offset| {
+                    *slot = match slot.checked_add(lockout_offset.offset) {
+                        None => {
+                            return Some(Err(serde::de::Error::custom("Invalid lockout offset")))
+                        }
+                        Some(slot) => slot,
+                    };
+                    let lockout = Lockout::new_with_confirmation_count(
+                        *slot,
+                        u32::from(lockout_offset.confirmation_count),
+                    );
+                    Some(Ok(lockout))
+                });
+        Ok(TowerSync {
+            root,
+            lockouts: lockouts.collect::<Result<_, _>>()?,
+            hash,
+            timestamp,
+            block_id,
+        })
+    }
+}

--- a/program/src/state/vote.rs
+++ b/program/src/state/vote.rs
@@ -1,0 +1,33 @@
+use {
+    serde::{Deserialize, Serialize},
+    solana_frozen_abi_macro::{frozen_abi, AbiExample},
+    solana_program::{
+        clock::{Slot, UnixTimestamp},
+        hash::Hash,
+    },
+};
+
+#[frozen_abi(digest = "Ch2vVEwos2EjAVqSHCyJjnN2MNX1yrpapZTGhMSCjWUH")]
+#[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone, AbiExample)]
+pub struct Vote {
+    /// A stack of votes starting with the oldest vote
+    pub slots: Vec<Slot>,
+    /// signature of the bank's state at the last slot
+    pub hash: Hash,
+    /// processing timestamp of last slot
+    pub timestamp: Option<UnixTimestamp>,
+}
+
+impl Vote {
+    pub fn new(slots: Vec<Slot>, hash: Hash) -> Self {
+        Self {
+            slots,
+            hash,
+            timestamp: None,
+        }
+    }
+
+    pub fn last_voted_slot(&self) -> Option<Slot> {
+        self.slots.last().copied()
+    }
+}

--- a/program/src/state/vote_state_update.rs
+++ b/program/src/state/vote_state_update.rs
@@ -1,0 +1,151 @@
+use {
+    crate::state::lockout::Lockout,
+    serde::{Deserialize, Serialize},
+    solana_frozen_abi_macro::{frozen_abi, AbiExample},
+    solana_program::{
+        clock::{Slot, UnixTimestamp},
+        hash::Hash,
+    },
+    std::collections::VecDeque,
+};
+
+#[frozen_abi(digest = "GwJfVFsATSj7nvKwtUkHYzqPRaPY6SLxPGXApuCya3x5")]
+#[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone, AbiExample)]
+pub struct VoteStateUpdate {
+    /// The proposed tower
+    pub lockouts: VecDeque<Lockout>,
+    /// The proposed root
+    pub root: Option<Slot>,
+    /// signature of the bank's state at the last slot
+    pub hash: Hash,
+    /// processing timestamp of last slot
+    pub timestamp: Option<UnixTimestamp>,
+}
+
+impl From<Vec<(Slot, u32)>> for VoteStateUpdate {
+    fn from(recent_slots: Vec<(Slot, u32)>) -> Self {
+        let lockouts: VecDeque<Lockout> = recent_slots
+            .into_iter()
+            .map(|(slot, confirmation_count)| {
+                Lockout::new_with_confirmation_count(slot, confirmation_count)
+            })
+            .collect();
+        Self {
+            lockouts,
+            root: None,
+            hash: Hash::default(),
+            timestamp: None,
+        }
+    }
+}
+
+impl VoteStateUpdate {
+    pub fn new(lockouts: VecDeque<Lockout>, root: Option<Slot>, hash: Hash) -> Self {
+        Self {
+            lockouts,
+            root,
+            hash,
+            timestamp: None,
+        }
+    }
+
+    pub fn slots(&self) -> Vec<Slot> {
+        self.lockouts.iter().map(|lockout| lockout.slot()).collect()
+    }
+
+    pub fn last_voted_slot(&self) -> Option<Slot> {
+        self.lockouts.back().map(|l| l.slot())
+    }
+}
+
+pub mod serde_compact_vote_state_update {
+    use {
+        super::*,
+        serde::{Deserialize, Deserializer, Serialize, Serializer},
+        solana_program::{serde_varint, short_vec},
+    };
+
+    #[derive(Deserialize, Serialize, AbiExample)]
+    struct LockoutOffset {
+        #[serde(with = "serde_varint")]
+        offset: Slot,
+        confirmation_count: u8,
+    }
+
+    #[derive(Deserialize, Serialize)]
+    struct CompactVoteStateUpdate {
+        root: Slot,
+        #[serde(with = "short_vec")]
+        lockout_offsets: Vec<LockoutOffset>,
+        hash: Hash,
+        timestamp: Option<UnixTimestamp>,
+    }
+
+    pub fn serialize<S>(
+        vote_state_update: &VoteStateUpdate,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let lockout_offsets = vote_state_update.lockouts.iter().scan(
+            vote_state_update.root.unwrap_or_default(),
+            |slot, lockout| {
+                let Some(offset) = lockout.slot().checked_sub(*slot) else {
+                    return Some(Err(serde::ser::Error::custom("Invalid vote lockout")));
+                };
+                let Ok(confirmation_count) = u8::try_from(lockout.confirmation_count()) else {
+                    return Some(Err(serde::ser::Error::custom("Invalid confirmation count")));
+                };
+                let lockout_offset = LockoutOffset {
+                    offset,
+                    confirmation_count,
+                };
+                *slot = lockout.slot();
+                Some(Ok(lockout_offset))
+            },
+        );
+        let compact_vote_state_update = CompactVoteStateUpdate {
+            root: vote_state_update.root.unwrap_or(Slot::MAX),
+            lockout_offsets: lockout_offsets.collect::<Result<_, _>>()?,
+            hash: vote_state_update.hash,
+            timestamp: vote_state_update.timestamp,
+        };
+        compact_vote_state_update.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<VoteStateUpdate, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let CompactVoteStateUpdate {
+            root,
+            lockout_offsets,
+            hash,
+            timestamp,
+        } = CompactVoteStateUpdate::deserialize(deserializer)?;
+        let root = (root != Slot::MAX).then_some(root);
+        let lockouts =
+            lockout_offsets
+                .iter()
+                .scan(root.unwrap_or_default(), |slot, lockout_offset| {
+                    *slot = match slot.checked_add(lockout_offset.offset) {
+                        None => {
+                            return Some(Err(serde::de::Error::custom("Invalid lockout offset")))
+                        }
+                        Some(slot) => slot,
+                    };
+                    let lockout = Lockout::new_with_confirmation_count(
+                        *slot,
+                        u32::from(lockout_offset.confirmation_count),
+                    );
+                    Some(Ok(lockout))
+                });
+        Ok(VoteStateUpdate {
+            root,
+            lockouts: lockouts.collect::<Result<_, _>>()?,
+            hash,
+            timestamp,
+        })
+    }
+}


### PR DESCRIPTION
#### Problem

All of the non-deprecated state types from the original Vote program need to be 
added to the BPF version. This presents a great opportunity for organizing all 
of those types a little better, especially because they will live in one crate 
now!

#### Summary of Changes

Copy over a large chunk (not all) of the Vote program's state types into the new 
BPF crate and introduce a more organized module structure.

Note: Most of the rest of the state types require changes from `2.0`, pertaining
to Stake deserialization.